### PR TITLE
Adds the '.' operator and '$' vars.

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,10 +36,19 @@ matchFn {count: 12, user: 'alice'} # false
 matchFn {count: 50, user: 'George Michael'} # terribly, unfortunately, false
 ```
 
+You can also access properties on passed in objects, like so:
+
+```coffeescript
+zerkel = require 'zerkel'
+
+query = 'user.location = "open field west of a white house"'
+matchFn = zerkel.compile query
+matchFn {user: {name: 'bob', location: 'open field west of a white house'}} # true
+matchFn {user: {name: 'alice', location: 'middle earth'}} # false
+```
+
 ###Status
 [![Build Status](https://travis-ci.org/adzerk/zerkel.png?branch=master)](https://travis-ci.org/adzerk/zerkel)
-
-Currently in beta testing.
 
 ###License
 Apache 2.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zerkel",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "A compiler for the zerkel language",
   "dependencies": {
     "coffee-script": "1.7.1",

--- a/src/zerkel-parser.jison
+++ b/src/zerkel-parser.jison
@@ -1,21 +1,21 @@
 /* lexical grammar */
 %lex
 %%
-\s+                   {/* skip whitespace */}
-"and"|"AND"           {return 'AND';}
-"or"|"OR"             {return 'OR';}
-"not"|"NOT"           {return 'NOT';}
-"="                   {return '=';}
-"<>"                  {return '<>';}
-">"|"<"|"<="|">="     {return 'LTGT';}
-"contains"|"CONTAINS" {return 'CONTAINS';}
-"like"|"LIKE"         {return 'LIKE';}
-[0-9]+                {return 'INTEGER';}
-\"[^\"]*\"            {return 'STRING';}
-[A-Za-z]+             {return 'VAR';}
-"("                   {return 'OPEN';}
-")"                   {return 'CLOSE';}
-<<EOF>>               {return 'EOF';}
+\s+                          {/* skip whitespace */}
+"and"|"AND"                  {return 'AND';}
+"or"|"OR"                    {return 'OR';}
+"not"|"NOT"                  {return 'NOT';}
+"="                          {return '=';}
+"<>"                         {return '<>';}
+">"|"<"|"<="|">="            {return 'LTGT';}
+"contains"|"CONTAINS"        {return 'CONTAINS';}
+"like"|"LIKE"                {return 'LIKE';}
+[0-9]+                       {return 'INTEGER';}
+\"[^\"]*\"                   {return 'STRING';}
+[\$A-Za-z]+(\.[A-Za-z]+)*    {return 'VAR';}
+"("                          {return 'OPEN';}
+")"                          {return 'CLOSE';}
+<<EOF>>                      {return 'EOF';}
 
 /lex
 
@@ -63,5 +63,5 @@ value
     | STRING
         {$$ = yytext;}
     | VAR
-        {$$ = "_env['" + yytext + "']";}
+        {$$ = "_helpers['getIn'](_env, '" + yytext + "')";}
     ;

--- a/src/zerkel-parser.js
+++ b/src/zerkel-parser.js
@@ -108,7 +108,7 @@ case 12:this.$ = Number(yytext);
 break;
 case 13:this.$ = yytext;
 break;
-case 14:this.$ = "_env['" + yytext + "']";
+case 14:this.$ = "_helpers['getIn'](_env, '" + yytext + "')";
 break;
 }
 },
@@ -611,7 +611,7 @@ case 14:return 5;
 break;
 }
 },
-rules: [/^(?:\s+)/,/^(?:and|AND\b)/,/^(?:or|OR\b)/,/^(?:not|NOT\b)/,/^(?:=)/,/^(?:<>)/,/^(?:>|<|<=|>=)/,/^(?:contains|CONTAINS\b)/,/^(?:like|LIKE\b)/,/^(?:[0-9]+)/,/^(?:"[^\"]*")/,/^(?:[A-Za-z]+)/,/^(?:\()/,/^(?:\))/,/^(?:$)/],
+rules: [/^(?:\s+)/,/^(?:and|AND\b)/,/^(?:or|OR\b)/,/^(?:not|NOT\b)/,/^(?:=)/,/^(?:<>)/,/^(?:>|<|<=|>=)/,/^(?:contains|CONTAINS\b)/,/^(?:like|LIKE\b)/,/^(?:[0-9]+)/,/^(?:"[^\"]*")/,/^(?:[\$A-Za-z]+(\.[A-Za-z]+)*)/,/^(?:\()/,/^(?:\))/,/^(?:$)/],
 conditions: {"INITIAL":{"rules":[0,1,2,3,4,5,6,7,8,9,10,11,12,13,14],"inclusive":true}}
 };
 return lexer;

--- a/src/zerkel.coffee
+++ b/src/zerkel.coffee
@@ -15,7 +15,18 @@ module.exports.match = match = (val, pattern) ->
   if pattern[pattern.length - 1] == '*'
     return (val.indexOf(pattern[0..-2]) == 0) and val.length > pattern.length
 
-module.exports.helpers = helpers = {match: match}
+module.exports.getIn = getIn = (env, varName) ->
+  levels = varName.split(".")
+  out = env
+  for level in levels
+    unless out? and typeof out is 'object'
+      out = undefined
+      break
+
+    out = out[level]
+  return out
+
+module.exports.helpers = helpers = {match: match, getIn: getIn}
 
 module.exports.compile = (query) ->
   body = "return " + parser.parse(query)

--- a/test/zerkel.tests.coffee
+++ b/test/zerkel.tests.coffee
@@ -1,51 +1,73 @@
 assert = require('chai').assert
 compiler = require '../'
 
-makeTest = (query, bindings, expected) ->
-  it "#{query} with #{JSON.stringify(bindings)} should be #{expected}", ->
-    assert.equal expected, compiler.compile(query)(bindings)
+describe 'Match helper', ->
+  makeTest = (a, b, expected) ->
+    it "#{a} like #{b} should be #{expected}", ->
+      assert.equal expected, compiler.match(a, b)
 
-makeTest 'x > 1', {x: 2}, true
-makeTest 'x>1', {x: 1}, false
-makeTest 'x = "Hi Bob"', {x: 'Hi Bob'}, true
-makeTest 'x="Hi Bob"', {x: 'hi'}, false
-makeTest 'x <> "Hi Bob"', {x: 'Hi Bob'}, false
-makeTest 'x<>"Hi Bob"', {x: 'hi'}, true
-makeTest 'x > 1 and y < 10', {x: 5, y: 5}, true
-makeTest 'x > 1 and y < 10', {x: 5, y: 15}, false
-makeTest 'x > 1 or y < 10', {x: 5, y: 15}, true
-makeTest 'x > 1 or y < 10', {x: 1, y: 15}, false
-makeTest '(x > 1 and y < 10) or (x = 0)', {x: 5, y:5}, true
-makeTest '(x > 1 and y<10) or (x = 0)', {x: 0, y:15}, true
-makeTest '(x > 1 and y < 10) or (x = 0)', {x: 1, y:15}, false
-makeTest '(x > 1 and y < 10) and not (z > 10 or k = 0)', {x: 2, y: 5, z: 5, k:5}, true
-makeTest '(x>1 and y < 10) and not (z > 10 or k = 0)', {x: 2, y: 5, z: 5, k:0}, false
-makeTest '(x > 1 and y < 10) and not (z > 10 or k = 0)', {x: 2, y: 5, z: 15, k:1}, false
-makeTest '(x > 1 and y < 10) and not (z > 10 or k = 0)', {x: 1, y: 5, z: 5, k:5}, false
-makeTest 'x contains "foo"', {x: ["foo", "bar"]}, true
-makeTest 'x contains "foo"', {x: ["bar"]}, false
-makeTest('((keywords contains "c#" and keywords contains "performance") or (keywords contains "sql server")) and not (keywords contains "android")',
-         {keywords:["sql server"]}, true)
-makeTest('((keywords contains "c#" and keywords contains "performance") or (keywords contains "sql server")) and not (keywords contains "android")',
-         {keywords:["c#", "performance"]}, true)
-makeTest('((keywords contains "c#" and keywords contains "performance") or (keywords contains "sql server")) and not (keywords contains "android")',
-         {keywords:["sql server", "android"]}, false)
-makeTest('((keywords contains "c#" and keywords contains "performance") or (keywords contains "sql server")) and not (keywords contains "android")',
-         {keywords:["c#", "performance", "android"]}, false)
-makeTest('((keywords contains "c#" and keywords contains "performance") or (keywords contains "sql server")) and not (keywords contains "android")',
-         {keywords:["c#"]}, false)
-makeTest '"foo" = x', {x: "foo"}, true
-makeTest 'x like "foo*"', {x: "foobar"}, true
-makeTest 'x like "foo*"', {x: "foo"}, false
-makeTest 'array contains "Foo"', {}, false
+  makeTest "foo", "Foo*", false
+  makeTest "foo", "f*", true
+  makeTest "foo", "*oo", true
+  makeTest "loop", "*oo*", true
+  makeTest "a", "*", true
+  makeTest "abc", "d*", false
 
-makeTest = (a, b, expected) ->
-  it "#{a} like #{b} should be #{expected}", ->
-    assert.equal expected, compiler.match(a, b)
+describe "Get-in helper", ->
+  env = {foo: 1, bar: {zip: 'x'}, stringy: "HO HO HO"}
 
-makeTest "foo", "Foo*", false
-makeTest "foo", "f*", true
-makeTest "foo", "*oo", true
-makeTest "loop", "*oo*", true
-makeTest "a", "*", true
-makeTest "abc", "d*", false
+  makeTest = (env, path, expected) ->
+    it "getting #{path} in #{JSON.stringify(env)} should be #{expected}", ->
+      assert.equal expected, compiler.getIn(env, path)
+
+  makeTest env, "ping", undefined
+  makeTest env, "foo.zip", undefined
+  makeTest env, "stringy.2", undefined
+  makeTest env, "ping.zip", undefined
+  makeTest env, "foo", 1
+  makeTest env, "bar.zip", 'x'
+  makeTest env, "stringy", "HO HO HO"
+
+describe 'Language tests', ->
+  makeTest = (query, bindings, expected) ->
+    it "#{query} with #{JSON.stringify(bindings)} should be #{expected}", ->
+      assert.equal expected, compiler.compile(query)(bindings)
+
+  makeTest 'x > 1', {x: 2}, true
+  makeTest 'x>1', {x: 1}, false
+  makeTest 'x = "Hi Bob"', {x: 'Hi Bob'}, true
+  makeTest 'x="Hi Bob"', {x: 'hi'}, false
+  makeTest 'x <> "Hi Bob"', {x: 'Hi Bob'}, false
+  makeTest 'x<>"Hi Bob"', {x: 'hi'}, true
+  makeTest 'x > 1 and y < 10', {x: 5, y: 5}, true
+  makeTest 'x > 1 and y < 10', {x: 5, y: 15}, false
+  makeTest 'x > 1 or y < 10', {x: 5, y: 15}, true
+  makeTest 'x > 1 or y < 10', {x: 1, y: 15}, false
+  makeTest '(x > 1 and y < 10) or (x = 0)', {x: 5, y:5}, true
+  makeTest '(x > 1 and y<10) or (x = 0)', {x: 0, y:15}, true
+  makeTest '(x > 1 and y < 10) or (x = 0)', {x: 1, y:15}, false
+  makeTest '(x > 1 and y < 10) and not (z > 10 or k = 0)', {x: 2, y: 5, z: 5, k:5}, true
+  makeTest '(x>1 and y < 10) and not (z > 10 or k = 0)', {x: 2, y: 5, z: 5, k:0}, false
+  makeTest '(x > 1 and y < 10) and not (z > 10 or k = 0)', {x: 2, y: 5, z: 15, k:1}, false
+  makeTest '(x > 1 and y < 10) and not (z > 10 or k = 0)', {x: 1, y: 5, z: 5, k:5}, false
+  makeTest 'x contains "foo"', {x: ["foo", "bar"]}, true
+  makeTest 'x contains "foo"', {x: ["bar"]}, false
+  makeTest('((keywords contains "c#" and keywords contains "performance") or (keywords contains "sql server")) and not (keywords contains "android")',
+           {keywords:["sql server"]}, true)
+  makeTest('((keywords contains "c#" and keywords contains "performance") or (keywords contains "sql server")) and not (keywords contains "android")',
+           {keywords:["c#", "performance"]}, true)
+  makeTest('((keywords contains "c#" and keywords contains "performance") or (keywords contains "sql server")) and not (keywords contains "android")',
+           {keywords:["sql server", "android"]}, false)
+  makeTest('((keywords contains "c#" and keywords contains "performance") or (keywords contains "sql server")) and not (keywords contains "android")',
+           {keywords:["c#", "performance", "android"]}, false)
+  makeTest('((keywords contains "c#" and keywords contains "performance") or (keywords contains "sql server")) and not (keywords contains "android")',
+           {keywords:["c#"]}, false)
+  makeTest '"foo" = x', {x: "foo"}, true
+  makeTest 'x like "foo*"', {x: "foobar"}, true
+  makeTest 'x like "foo*"', {x: "foo"}, false
+  makeTest 'array contains "Foo"', {}, false
+  makeTest 'foo.bar = 1', {foo: {bar: 1}}, true
+  makeTest 'foo.bar = zip', {foo: {bar: 1}, zip: 1}, true
+  makeTest '1 > foo.bar', {foo: {bar: 1}}, false
+  makeTest 'foo.bar < zip.ping', {foo: {bar: 1}, zip: {ping: 2}}, true
+  makeTest '$foo.bar = 1', {"$foo": {bar: 1}}, true


### PR DESCRIPTION
This will allow us to do things like inject '$request.ip' into zerkel targeting.

I moved some things around in testing, sorry about that. Wanted a little more hierarchy.
