### PR TITLE
Separate construction of predicate function from Zerkel compilation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zerkel",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "A compiler for the zerkel language",
   "dependencies": {
     "coffee-script": "1.7.1",

--- a/src/zerkel.coffee
+++ b/src/zerkel.coffee
@@ -28,7 +28,9 @@ module.exports.getIn = getIn = (env, varName) ->
 
 module.exports.helpers = helpers = {match: match, getIn: getIn}
 
-module.exports.compile = (query) ->
-  body = "return " + parser.parse(query)
-  fn = new Function('_helpers', '_env', body)
+module.exports.makePredicate = makePredicate = (body) ->
+  fn = new Function('_helpers', '_env', "return " + body)
   return (env) -> Boolean fn helpers, env
+
+module.exports.compile = (query) ->
+  return makePredicate(parser.parse(query))


### PR DESCRIPTION
- This separation will facilitate caching of compiled Zerkel queries.
  The parsed Zerkel can be serialized whereas the predicate function
  only exists in memory.